### PR TITLE
chore: Add prettier configuration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "hooks": {
       "pre-commit": "npm run lint"
     }
+  },
+  "prettier": {
+    "tabWidth": 4
   }
 }


### PR DESCRIPTION
Default indent for prettier is 2 making autoformatting incompatible with our current coding style.